### PR TITLE
Add experimental generic Firefox configuration to LibreWolf

### DIFF
--- a/configs/home/bricked/default.nix
+++ b/configs/home/bricked/default.nix
@@ -51,7 +51,6 @@
   programs.cava.enable = true;
 
   # Apps
-  programs.firefox.enable = true;
   programs.librewolf.enable = true;
   programs.vesktop.enable = true;
   home.packages = with pkgs; [heroic];

--- a/configs/home/bricked/default.nix
+++ b/configs/home/bricked/default.nix
@@ -51,7 +51,7 @@
   programs.cava.enable = true;
 
   # Apps
-	programs.firefox.enable = true;
+  programs.firefox.enable = true;
   programs.librewolf.enable = true;
   programs.vesktop.enable = true;
   home.packages = with pkgs; [heroic];

--- a/configs/home/bricked/default.nix
+++ b/configs/home/bricked/default.nix
@@ -51,41 +51,7 @@
   programs.cava.enable = true;
 
   # Apps
-  programs.firefox = {
-    enable = true;
-    profiles = {
-      bricked = {
-        name = "bricked";
-        extensions = with config.nur.repos.rycee.firefox-addons; [
-          ublock-origin
-          bitwarden
-          darkreader
-          libredirect
-        ];
-        search = {
-          default = "DuckDuckGo";
-          force = true;
-          engines = {
-            "Google".metaData.hidden = true;
-            "Bing".metaData.hidden = true;
-          };
-        };
-        bookmarks = [
-          {
-            name = "NixDots";
-            tags = ["nix"];
-            keyword = "nixdots";
-            url = "https://github.com/brckd/nixdots";
-          }
-        ];
-        settings = {
-          "extensions.autoDisableScopes" = 0;
-          "browser.toolbars.bookmarks.visibility" = "never";
-          "browser.newtabpage.activity-stream.improvesearch.topSiteSearchShortcuts" = false;
-        };
-      };
-    };
-  };
+	programs.firefox.enable = true;
   programs.librewolf.enable = true;
   programs.vesktop.enable = true;
   home.packages = with pkgs; [heroic];

--- a/configs/home/bricked/default.nix
+++ b/configs/home/bricked/default.nix
@@ -1,4 +1,8 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  config,
+  ...
+}: {
   home = {
     username = "bricked";
     homeDirectory = "/home/bricked";
@@ -47,6 +51,41 @@
   programs.cava.enable = true;
 
   # Apps
+  programs.firefox = {
+    enable = true;
+    profiles = {
+      bricked = {
+        name = "bricked";
+        extensions = with config.nur.repos.rycee.firefox-addons; [
+          ublock-origin
+          bitwarden
+          darkreader
+          libredirect
+        ];
+        search = {
+          default = "DuckDuckGo";
+          force = true;
+          engines = {
+            "Google".metaData.hidden = true;
+            "Bing".metaData.hidden = true;
+          };
+        };
+        bookmarks = [
+          {
+            name = "NixDots";
+            tags = ["nix"];
+            keyword = "nixdots";
+            url = "https://github.com/brckd/nixdots";
+          }
+        ];
+        settings = {
+          "extensions.autoDisableScopes" = 0;
+          "browser.toolbars.bookmarks.visibility" = "never";
+          "browser.newtabpage.activity-stream.improvesearch.topSiteSearchShortcuts" = false;
+        };
+      };
+    };
+  };
   programs.librewolf.enable = true;
   programs.vesktop.enable = true;
   home.packages = with pkgs; [heroic];

--- a/flake.lock
+++ b/flake.lock
@@ -364,15 +364,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1719418488,
-        "narHash": "sha256-Hu75KIbGLJA8qe42rO5WkRQ+E+BuzjS42bNEZcy9zT8=",
+        "lastModified": 1719424993,
+        "narHash": "sha256-LBJ/xobh9to6kxxbAZY7MkjR1gZwcB0IozEh/J+kWqg=",
         "owner": "brckd",
         "repo": "home-manager",
-        "rev": "607f969f5dca2dc100cbc53e24ab49ac24ef8987",
+        "rev": "157d5c51767260623ad66490364b0e4a6f90301b",
         "type": "github"
       },
       "original": {
         "owner": "brckd",
+        "ref": "firefox-forks",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -364,16 +364,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1719424993,
-        "narHash": "sha256-LBJ/xobh9to6kxxbAZY7MkjR1gZwcB0IozEh/J+kWqg=",
+        "lastModified": 1720857381,
+        "narHash": "sha256-BWLoJUTuSGjlkn9vvD6y0n4UpBHb5h+nq+ljhN7b6IM=",
         "owner": "brckd",
         "repo": "home-manager",
-        "rev": "157d5c51767260623ad66490364b0e4a6f90301b",
+        "rev": "d5f4073afd78cd44386a9871650d68b005c3b7b8",
         "type": "github"
       },
       "original": {
         "owner": "brckd",
-        "ref": "firefox-forks",
+        "ref": "firefox/librewolf",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
     "base16-helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1696727917,
-        "narHash": "sha256-FVrbPk+NtMra0jtlC5oxyNchbm8FosmvXIatkRbYy1g=",
+        "lastModified": 1720809814,
+        "narHash": "sha256-numb3xigRGnr/deF7wdjBwVg7fpbTH7reFDkJ75AJkY=",
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "rev": "dbe1480d99fe80f08df7970e471fac24c05f2ddb",
+        "rev": "34f41987bec14c0f3f6b2155c19787b1f6489625",
         "type": "github"
       },
       "original": {
@@ -167,11 +167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720636134,
-        "narHash": "sha256-S7DYiC9yFbvEG2ewOVfgcAlgP6F4tBQduYLeoESrv/E=",
+        "lastModified": 1720726305,
+        "narHash": "sha256-B8apk0nN1712980meOzUVqxRQkBomCa7TZQg9Uuj/eI=",
         "owner": "emmanuelrosa",
         "repo": "erosanix",
-        "rev": "f1083bcc154fff088898e3a847af1d5351e8e4c4",
+        "rev": "0cd30807410fe7aefd10f85ab1591491f8245602",
         "type": "github"
       },
       "original": {
@@ -280,11 +280,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1720253561,
-        "narHash": "sha256-9KUEonUkohfF6Eiuni646rAK8Ta/rbXn4XQJ5IgNl6Q=",
+        "lastModified": 1720839352,
+        "narHash": "sha256-XbUEsjyDB5UeILBJ9RBQgbYAFO4r/i5MxHsGoymXfis=",
         "owner": "getchoo",
         "repo": "nix-exprs",
-        "rev": "1b74fd04fde23753f4463fa9d2398ea010794ac5",
+        "rev": "0bf7c814c371092f20cd2219e94505ad2def001f",
         "type": "github"
       },
       "original": {
@@ -364,15 +364,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1720616874,
-        "narHash": "sha256-yyGDjpHCoG3zSCpN7yLpItu56508quscOrYlRUxb3Mw=",
-        "owner": "nix-community",
+        "lastModified": 1719418488,
+        "narHash": "sha256-Hu75KIbGLJA8qe42rO5WkRQ+E+BuzjS42bNEZcy9zT8=",
+        "owner": "brckd",
         "repo": "home-manager",
-        "rev": "f749fabeccb1587e4c1562e4f818cf33b8f77a51",
+        "rev": "607f969f5dca2dc100cbc53e24ab49ac24ef8987",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "brckd",
         "repo": "home-manager",
         "type": "github"
       }
@@ -384,11 +384,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720599442,
-        "narHash": "sha256-jdm+sKVbBXoyrxcHbVaV0htlpq2iFR+eJw3Xe/DPcDo=",
+        "lastModified": 1720845312,
+        "narHash": "sha256-yPhAsJTpyoIPQZJGC8Fw8W2lAXyhLoTn+HP20bmfkfk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "cf297a8d248db6a455b60133f6c0029c04ebe50e",
+        "rev": "5ce8503cf402cf76b203eba4b7e402bea8e44abc",
         "type": "github"
       },
       "original": {
@@ -461,11 +461,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720418205,
-        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
+        "lastModified": 1720542800,
+        "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "655a58a72a6601292512670343087c2d75d859c1",
+        "rev": "feb2849fdeb70028c70d73b848214b00d324a497",
         "type": "github"
       },
       "original": {
@@ -551,11 +551,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720599498,
-        "narHash": "sha256-pFnYV+cUln/koTwe9UNzAzHwpdsw90oTMy6PNInkVw8=",
+        "lastModified": 1720804407,
+        "narHash": "sha256-mLVzkOpfOqYPmwjAAHRmeVUoOUmpLpxmfKDObT1FVtc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "34c3c026b4c9ac1cc37eb97313535aace6b6400b",
+        "rev": "89d74cdce173223f57754c6a315c929f8fc14229",
         "type": "github"
       },
       "original": {
@@ -620,11 +620,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1720641645,
-        "narHash": "sha256-OpvojXGHWGMj1OIt98lCTvWLcFQAc8YwKlr1Qs7KW2E=",
+        "lastModified": 1720857081,
+        "narHash": "sha256-9Uxy0EFrUoScUVwrpOkRvCL2q6/HRYhIKTrYKI8oWcQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fa0fa80d15a7ad752a9c3f5553e695e4b10d772",
+        "rev": "562a99e4477552a8b7ee6bf84b5289b413296503",
         "type": "github"
       },
       "original": {
@@ -722,11 +722,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719525570,
-        "narHash": "sha256-xSO/H67GAHEW0siD2PHoO/e97MbROL3r3s5SpF6A6Dc=",
+        "lastModified": 1720818679,
+        "narHash": "sha256-u9PqY7O6TN42SLeb0e6mnYAgQOoQmclaVSHfLKMpmu0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1ff9d37d27377bfe8994c24a8d6c6c1734ffa116",
+        "rev": "29148118cc33f08b71058e1cda7ca017f5300b51",
         "type": "github"
       },
       "original": {
@@ -758,11 +758,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719887753,
-        "narHash": "sha256-p0B2r98UtZzRDM5miGRafL4h7TwGRC4DII+XXHDHqek=",
+        "lastModified": 1720818892,
+        "narHash": "sha256-f52x9srIcqQm1Df3T+xYR5P6VfdnDFa2vkkcLhlTp6U=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "bdb6355009562d8f9313d9460c0d3860f525bc6c",
+        "rev": "5b002f8a53ed04c1a4177e7b00809d57bd2c696f",
         "type": "github"
       },
       "original": {
@@ -778,11 +778,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720507012,
-        "narHash": "sha256-QIeZ43t9IVB4dLsFaWh2f4C7JSRfK7p+Y1U9dULsLXU=",
+        "lastModified": 1720818892,
+        "narHash": "sha256-f52x9srIcqQm1Df3T+xYR5P6VfdnDFa2vkkcLhlTp6U=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8b63fe8cf7892c59b3df27cbcab4d5644035d72f",
+        "rev": "5b002f8a53ed04c1a4177e7b00809d57bd2c696f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
 
     # Systems
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:brckd/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
 
     # Systems
     home-manager = {
-      url = "github:brckd/home-manager/firefox-forks";
+      url = "github:brckd/home-manager/firefox/librewolf";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
 
     # Systems
     home-manager = {
-      url = "github:brckd/home-manager";
+      url = "github:brckd/home-manager/firefox-forks";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -21,6 +21,7 @@
     ./kitty
     ./nixvim
     ./lf
+		./firefox
     ./librewolf
     ./cava
     ./vesktop

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -21,7 +21,7 @@
     ./kitty
     ./nixvim
     ./lf
-		./firefox
+    ./firefox
     ./librewolf
     ./cava
     ./vesktop

--- a/modules/home/firefox/default.nix
+++ b/modules/home/firefox/default.nix
@@ -35,19 +35,19 @@ in {
           ];
           settings = {
             "extensions.autoDisableScopes" = 0; # Enable extensions
-						"toolkit.legacyUserProfileCustomizations.stylesheets" = true; # Enable userchrome
-						"browser.aboutConfig.showWarning" = false;
+            "toolkit.legacyUserProfileCustomizations.stylesheets" = true; # Enable userchrome
+            "browser.aboutConfig.showWarning" = false;
 
-						# Blank homepage
-						"browser.newtabpage.enable" = false;
-						"browser.startup.homepage" = "chrome://browser/content/blanktab.html";
+            # Blank homepage
+            "browser.newtabpage.enable" = false;
+            "browser.startup.homepage" = "chrome://browser/content/blanktab.html";
             "browser.toolbars.bookmarks.visibility" = "never";
 
-						# Toolbar customization
-						"browser.uiCustomization.state" = builtins.readFile ./toolbar.json;
+            # Toolbar customization
+            "browser.uiCustomization.state" = builtins.readFile ./toolbar.json;
           };
 
-					userChrome = builtins.readFile ./userChrome.css;
+          userChrome = builtins.readFile ./userChrome.css;
         };
       };
     };

--- a/modules/home/firefox/default.nix
+++ b/modules/home/firefox/default.nix
@@ -4,10 +4,10 @@
   ...
 }:
 with lib; let
-  cfg = config.programs.firefox;
+  cfg = config.programs.librewolf;
 in {
   config = mkIf cfg.enable {
-    programs.firefox = {
+    programs.librewolf = {
       profiles = {
         default = {
           name = "Default";

--- a/modules/home/firefox/default.nix
+++ b/modules/home/firefox/default.nix
@@ -34,10 +34,20 @@ in {
             }
           ];
           settings = {
-            "extensions.autoDisableScopes" = 0;
+            "extensions.autoDisableScopes" = 0; # Enable extensions
+						"toolkit.legacyUserProfileCustomizations.stylesheets" = true; # Enable userchrome
+						"browser.aboutConfig.showWarning" = false;
+
+						# Blank homepage
+						"browser.newtabpage.enable" = false;
+						"browser.startup.homepage" = "chrome://browser/content/blanktab.html";
             "browser.toolbars.bookmarks.visibility" = "never";
-            "browser.newtabpage.activity-stream.improvesearch.topSiteSearchShortcuts" = false;
+
+						# Toolbar customization
+						"browser.uiCustomization.state" = builtins.readFile ./toolbar.json;
           };
+
+					userChrome = builtins.readFile ./userChrome.css;
         };
       };
     };

--- a/modules/home/firefox/default.nix
+++ b/modules/home/firefox/default.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.programs.firefox;
+in {
+  config = mkIf cfg.enable {
+    programs.firefox = {
+      profiles = {
+        default = {
+          name = "Default";
+          extensions = with config.nur.repos.rycee.firefox-addons; [
+            ublock-origin
+            bitwarden
+            darkreader
+            libredirect
+          ];
+          search = {
+            default = "DuckDuckGo";
+            force = true;
+            engines = {
+              "Google".metaData.hidden = true;
+              "Bing".metaData.hidden = true;
+            };
+          };
+          bookmarks = [
+            {
+              name = "GitHub";
+              tags = ["git"];
+              keyword = "github";
+              url = "https://github.com/";
+            }
+          ];
+          settings = {
+            "extensions.autoDisableScopes" = 0;
+            "browser.toolbars.bookmarks.visibility" = "never";
+            "browser.newtabpage.activity-stream.improvesearch.topSiteSearchShortcuts" = false;
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/home/firefox/toolbar.json
+++ b/modules/home/firefox/toolbar.json
@@ -1,0 +1,38 @@
+{
+  "placements": {
+    "widget-overflow-fixed-list": [],
+    "unified-extensions-area": [
+      "ublock0_raymondhill_net-browser-action",
+      "7esoorv3_alefvanoon_anonaddy_me-browser-action",
+      "addon_darkreader_org-browser-action"
+    ],
+    "nav-bar": [
+      "back-button",
+      "forward-button",
+      "urlbar-container",
+      "downloads-button",
+      "_446900e4-71c2-419f-a6a7-df9c091e268b_-browser-action",
+      "unified-extensions-button"
+    ],
+    "toolbar-menubar": ["menubar-items"],
+    "TabsToolbar": ["tabbrowser-tabs", "new-tab-button", "alltabs-button"],
+    "PersonalToolbar": ["import-button", "personal-bookmarks"]
+  },
+  "seen": [
+    "save-to-pocket-button",
+    "7esoorv3_alefvanoon_anonaddy_me-browser-action",
+    "addon_darkreader_org-browser-action",
+    "ublock0_raymondhill_net-browser-action",
+    "_446900e4-71c2-419f-a6a7-df9c091e268b_-browser-action",
+    "developer-button"
+  ],
+  "dirtyAreaCache": [
+    "unified-extensions-area",
+    "nav-bar",
+    "PersonalToolbar",
+    "toolbar-menubar",
+    "TabsToolbar"
+  ],
+  "currentVersion": 20,
+  "newElementCount": 4
+}

--- a/modules/home/firefox/toolbar.json
+++ b/modules/home/firefox/toolbar.json
@@ -15,7 +15,7 @@
       "unified-extensions-button"
     ],
     "toolbar-menubar": ["menubar-items"],
-    "TabsToolbar": ["tabbrowser-tabs", "new-tab-button", "alltabs-button"],
+    "TabsToolbar": ["tabbrowser-tabs", "alltabs-button"],
     "PersonalToolbar": ["import-button", "personal-bookmarks"]
   },
   "seen": [
@@ -34,5 +34,5 @@
     "TabsToolbar"
   ],
   "currentVersion": 20,
-  "newElementCount": 4
+  "newElementCount": 7
 }

--- a/modules/home/firefox/userChrome.css
+++ b/modules/home/firefox/userChrome.css
@@ -1,0 +1,6 @@
+@namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+
+#back-button,
+#forward-button {
+  display: none !important;
+}

--- a/modules/home/firefox/userChrome.css
+++ b/modules/home/firefox/userChrome.css
@@ -1,6 +1,7 @@
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
 #back-button,
-#forward-button {
+#forward-button,
+#alltabs-button {
   display: none !important;
 }

--- a/modules/home/librewolf/default.nix
+++ b/modules/home/librewolf/default.nix
@@ -1,6 +1,5 @@
 {
   config,
-  pkgs,
   lib,
   ...
 }:


### PR DESCRIPTION
Uses the experimental https://github.com/brckd/home-manager/tree/firefox/librewolf branch to add generic Firefox configs to LibreWolf, which will be superceded by https://github.com/nix-community/home-manager/pull/5684.